### PR TITLE
Fixed front matter on About page

### DIFF
--- a/content/about.md
+++ b/content/about.md
@@ -1,9 +1,9 @@
-+++
+---
 title = "About"
 date = "2025-03-26"
 aliases = ["about-us","about-hugo","contact"]
 [ author ]
   name = "AGNU Authors"
-+++
+---
 
 Something About AGNU


### PR DESCRIPTION
The About page had incorrect front matter using `+++`. 
This has been replaced with `---`, ensuring correct rendering.
Closes issue #3